### PR TITLE
(fix): output scripts folder mismatch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,7 +118,7 @@ gulp.task('typescript', function () {
     experimentalDecorators: true,
     inlineSourceMap: true,
     inlineSources: true,
-    out: 'scripts/output.js'
+    out: 'output.js'
   }));
 
   return tsResult.js.pipe(gulp.dest('.tmp'))


### PR DESCRIPTION
There is an error while gulp default task is running:
`Error in plugin 'gulp-vulcanize'`
`Message:`
    `ENOENT: no such file or directory, open '/usr/local/google/home/azahreba/Desktop/Polymer-Super-Kit/www/scripts/output.js'`
`Details:`
    `errno: -2`
    `code: ENOENT`
    `syscall: open`
    `path: /usr/local/google/home/azahreba/Desktop/Polymer-Super-Kit/www/scripts/output.js`
    `fileName: /usr/local/google/home/azahreba/Desktop/Polymer-Super-Kit/www/index.html`

Fix: directories (scripts/**scripts/**output.js) mismatch.
